### PR TITLE
Sub-folder scanning works, processing photos for MOVED_TO also

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 This Android app allows photographers to upload photos in real time so that event guests can get their photos. A listener is looking for new photos created in the directory /Nikon downloads of the phone's internal storage. It also looks for a watermark png file in the directory /Watermark, file name watermark.png. It uploads these photos to the /upload-photo endpoint hosted on Render currently (https://c2u-api.onrender.com/upload-photo).
 
 Pending:
-1. ~~Sony app creates new folders abruptly for new photos. Need to scan all child folders for new photos to make this work reliably with Sony cameras.~~
+1. Sony app creates new folders abruptly for new photos. Need to scan all child folders for new photos to make this work reliably with Sony cameras.
 2. Upload photos one at a time instead of multiple at once. Since mobile internet bandwidth is limited, trying to upload multiple photos at once may lead to timeout for all requests.
 2. Implement autoscroll as per logs
 ~~3. Allow scrolling the app~~
@@ -10,3 +10,5 @@ Pending:
 5. Check memory usage of app and optimise if needed
 ~~6. Handle portrait photos watermarking~~
 7. Aggressive compression of photos after 2 failed attempts to make uploads work with low network speeds
+8. ~~Handle Sony's file transfer system where CLOSE_WRITE event is triggered for temp file creation and then a MOVED_TO event is triggered for the actual file creation~~
+9. Ability to read external storage on Android 13 to access photos created beyond this app's file scope

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 This Android app allows photographers to upload photos in real time so that event guests can get their photos. A listener is looking for new photos created in the directory /Nikon downloads of the phone's internal storage. It also looks for a watermark png file in the directory /Watermark, file name watermark.png. It uploads these photos to the /upload-photo endpoint hosted on Render currently (https://c2u-api.onrender.com/upload-photo).
 
 Pending:
-1. Sony app creates new folders abruptly for new photos. Need to scan all child folders for new photos to make this work reliably with Sony cameras.
+~~1. Sony app creates new folders abruptly for new photos. Need to scan all child folders for new photos to make this work reliably with Sony cameras.~~
 2. Upload photos one at a time instead of multiple at once. Since mobile internet bandwidth is limited, trying to upload multiple photos at once may lead to timeout for all requests.
 2. Implement autoscroll as per logs
 ~~3. Allow scrolling the app~~

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -7,6 +7,9 @@
     <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE"/>
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES"/>
+    <uses-permission android:name="android.permission.READ_MEDIA_VIDEO"/>
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
 
     <application
         android:allowBackup="true"

--- a/app/src/main/java/com/example/c2u_photographer_1/MainActivity.kt
+++ b/app/src/main/java/com/example/c2u_photographer_1/MainActivity.kt
@@ -54,7 +54,9 @@ class MainActivity : AppCompatActivity() {
     // Nikon on Redmi K20:
     val photoDir = "/storage/emulated/0/Nikon downloads"
     // Bangalore photographer's Sony A7M3:
-    // val photoDir = "/storage/emulated/0/DCIM/Transfer & Tagging add-on/e522445b-bb7e-468b-9c1f-b5ffd19c2947/674d5a5a-6be5-4f9b-82b9-92231010313d/c144a81b-77db-4d8a-815b-1da75ec8f678"
+    // val photoDir = "/storage/emulated/0/DCIM/Transfer & Tagging add-on"
+    // val photoDir = "/storage/emulated/0/DCIM/Transfer & Tagging add-on/e522445b-bb7e-468b-9c1f-b5ffd19c2947/6c00f2fc-7bd3-48cc-a7e5-4a151aaed57b/b63df105-c1ae-4051-83dd-ab8a0bd3feef"
+    // val photoDir = "/storage/emulated/0/DCIM/Transfer & Tagging add-on/e522445b-bb7e-468b-9c1f-b5ffd19c2947/2cfbb0a6-3d29-43e1-a59e-9f39124d15c4"
     // Hemant Royale Camera's Sony Camera below:
     // val photoDir = "/storage/emulated/0/DCIM/Transfer & Tagging add-on/e522445b-bb7e-468b-9c1f-b5ffd19c2947/a30304c5-5f08-4670-a8a9-5de328ce82d5/02d9ec51-f471-4afb-8476-782634a762f6"
     // val photoDir = "/storage/emulated/10/DCIM/Transfer & Tagging add-on/be86c1fd-3dec-4628-80de-5dd2b088f692/3a760bb9-876b-4836-95e7-cba9f2c6e2d3/e5528206-d021-4fdf-9ad6-b9efd87147d2"
@@ -79,7 +81,9 @@ class MainActivity : AppCompatActivity() {
     var logTextView: TextView? = null
 
     // We'll monitor the following events:
-    val mask = FileObserver.CLOSE_WRITE or FileObserver.CREATE
+    val mask = FileObserver.CLOSE_WRITE or FileObserver.MOVED_TO or FileObserver.CREATE
+    // val mask = FileObserver.CLOSE_WRITE
+    // val mask = FileObserver.ALL_EVENTS
 
     // This is the method that is called when the activity is created
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -177,7 +181,7 @@ class MainActivity : AppCompatActivity() {
         try {
             logMessage(
                 "Called startWatchingDirectory with directory: ${directory.path}",
-                Color.WHITE
+                Color.GRAY
             )
             directory.listFiles()?.forEach { file ->
                 if (file.isDirectory) {
@@ -190,11 +194,13 @@ class MainActivity : AppCompatActivity() {
                 override fun onEvent(event: Int, path: String?) {
                     logMessage(
                         "File observer event: $event, path: $path, current time: ${System.currentTimeMillis()}",
-                        Color.WHITE
+                        Color.GRAY
                     )
-                    if (event == FileObserver.CLOSE_WRITE && path != null && isFileStable(
+                    // logMessage("Event is equal to close write or moved to? ${event == FileObserver.CLOSE_WRITE || event == FileObserver.MOVED_TO}", Color.GRAY)
+                    if ((event == FileObserver.CLOSE_WRITE || event == FileObserver.MOVED_TO) && path != null && isFileStable(
                             File("${directory.path}/$path")
                         )){
+                        // if (event == FileObserver.CLOSE_WRITE && path != null){
                         val filePath = "${directory.path}/$path"
                         // Check if it's a directory or a file
                         if (File(filePath).isDirectory) {
@@ -204,7 +210,7 @@ class MainActivity : AppCompatActivity() {
                                     File(   
                                         filePath
                                     ).path
-                                }", Color.WHITE
+                                }", Color.GRAY
                             )
                             startWatchingDirectory(File(filePath))
                         } else {
@@ -214,7 +220,7 @@ class MainActivity : AppCompatActivity() {
                                     File(
                                         filePath
                                     ).path
-                                }", Color.WHITE
+                                }", Color.GRAY
                             )
                             processAndUploadImageFile(filePath)
                         }
@@ -587,7 +593,7 @@ class MainActivity : AppCompatActivity() {
     }
 
     // This is the method that logs a message to the log text view and scrolls it to the bottom
-    fun logMessage(message: String, color: Int = Color.WHITE) {
+    fun logMessage(message: String, color: Int = Color.GRAY) {
         runOnUiThread {
             // Save current color
             // val originalColor = logTextView?.currentTextColor

--- a/app/src/main/java/com/example/c2u_photographer_1/MainActivity.kt
+++ b/app/src/main/java/com/example/c2u_photographer_1/MainActivity.kt
@@ -52,9 +52,9 @@ class MainActivity : AppCompatActivity() {
 
     // This is the directory where the photos are getting added
     // Nikon on Redmi K20:
-    val photoDir = "/storage/emulated/0/Nikon downloads"
+    // val photoDir = "/storage/emulated/0/Nikon downloads"
     // Bangalore photographer's Sony A7M3:
-    // val photoDir = "/storage/emulated/0/DCIM/Transfer & Tagging add-on"
+    val photoDir = "/storage/emulated/0/DCIM/Transfer & Tagging add-on"
     // val photoDir = "/storage/emulated/0/DCIM/Transfer & Tagging add-on/e522445b-bb7e-468b-9c1f-b5ffd19c2947/6c00f2fc-7bd3-48cc-a7e5-4a151aaed57b/b63df105-c1ae-4051-83dd-ab8a0bd3feef"
     // val photoDir = "/storage/emulated/0/DCIM/Transfer & Tagging add-on/e522445b-bb7e-468b-9c1f-b5ffd19c2947/2cfbb0a6-3d29-43e1-a59e-9f39124d15c4"
     // Hemant Royale Camera's Sony Camera below:
@@ -76,12 +76,14 @@ class MainActivity : AppCompatActivity() {
     // This is the file observer object that monitors the photo directory for changes
     var fileObserver: FileObserver? = null
 //    var observer: FileObserver? = null
+    private val allFileObservers = mutableListOf<FileObserver>()
 
     // This is the text view object that displays the logs to the user
     var logTextView: TextView? = null
 
     // We'll monitor the following events:
-    val mask = FileObserver.CLOSE_WRITE or FileObserver.MOVED_TO or FileObserver.CREATE
+    val newFolderEvent = 1073742080
+    val mask = FileObserver.CLOSE_WRITE or FileObserver.MOVED_TO or FileObserver.CREATE or newFolderEvent
     // val mask = FileObserver.CLOSE_WRITE
     // val mask = FileObserver.ALL_EVENTS
 
@@ -197,7 +199,7 @@ class MainActivity : AppCompatActivity() {
                         Color.GRAY
                     )
                     // logMessage("Event is equal to close write or moved to? ${event == FileObserver.CLOSE_WRITE || event == FileObserver.MOVED_TO}", Color.GRAY)
-                    if ((event == FileObserver.CLOSE_WRITE || event == FileObserver.MOVED_TO) && path != null && isFileStable(
+                    if ((event == FileObserver.CLOSE_WRITE || event == FileObserver.MOVED_TO || event == newFolderEvent) && path != null && isFileStable(
                             File("${directory.path}/$path")
                         )){
                         // if (event == FileObserver.CLOSE_WRITE && path != null){
@@ -228,6 +230,7 @@ class MainActivity : AppCompatActivity() {
                 }
             }
             (fileObserver as FileObserver).startWatching()
+            allFileObservers.add(fileObserver as FileObserver)
         } catch (e: Exception) {
             // Log an exception message
             logMessage("Exception while starting file observer: ${e.message}", Color.RED)
@@ -255,7 +258,9 @@ class MainActivity : AppCompatActivity() {
     fun stopFileObserver() {
         try {
             // Stop watching for events in the photo directory
-            fileObserver?.stopWatching()
+            // fileObserver?.stopWatching()
+            allFileObservers.forEach { it.stopWatching() }
+            allFileObservers.clear()
 
             // Log a success message
             logMessage("File observer stopped successfully")


### PR DESCRIPTION
Sub-folder scanning works recursively. Checks for new photos even in new folders created after the app is started. Sony's Transfer & Tagging app creates new folders randomly and adds new photos there. So we need to scan throughout the parent directory: /storage/emulated/0/DCIM/Transfer & Tagging add-on . We're also processing MOVED_TO events. This is done because Sony triggers CLOSE_WRITE for their temp files and then a MOVED_TO event is triggered for when the temp file becomes the final file. Merging dev branch with master.